### PR TITLE
Apply fixes to tenants

### DIFF
--- a/defaults/defaults.yaml
+++ b/defaults/defaults.yaml
@@ -177,3 +177,5 @@ defaults:
           redirect_policy_name_suffix: ""
     tenants:
       orchestrator_only: true
+      users:
+        - name: admin

--- a/ndo_tenants.tf
+++ b/ndo_tenants.tf
@@ -1,5 +1,5 @@
 locals {
-  default_users = distinct(concat([{ name = "admin" }], try(local.defaults.ndo.tenants.users, [])))
+  default_users = distinct(concat([{ name = "admin" }], local.defaults.ndo.tenants.users))
   tenant_users = flatten(distinct([
     for tenant in try(local.ndo.tenants, []) : [
       for user in distinct(concat(try(tenant.users, []), local.default_users)) : [user.name]


### PR DESCRIPTION
I have removed some redundancy from the code which was creating multiple entries in the data source by including the tenant in the key.

We need to include the "admin" user otherwise it will fail to be idempotent. We also need to cater for the scenario where the provider user is not "admin".