### PR TITLE
Optimise unmanaged data sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,8 +167,10 @@ module "site" {
 | [mso_tenant.tenant](https://registry.terraform.io/providers/CiscoDevNet/mso/latest/docs/resources/tenant) | resource |
 | [mso_schema.schema](https://registry.terraform.io/providers/CiscoDevNet/mso/latest/docs/data-sources/schema) | data source |
 | [mso_site.site](https://registry.terraform.io/providers/CiscoDevNet/mso/latest/docs/data-sources/site) | data source |
-| [mso_tenant.tenant](https://registry.terraform.io/providers/CiscoDevNet/mso/latest/docs/data-sources/tenant) | data source |
-| [mso_user.user](https://registry.terraform.io/providers/CiscoDevNet/mso/latest/docs/data-sources/user) | data source |
+| [mso_site.template_site](https://registry.terraform.io/providers/CiscoDevNet/mso/latest/docs/data-sources/site) | data source |
+| [mso_site.tenant_site](https://registry.terraform.io/providers/CiscoDevNet/mso/latest/docs/data-sources/site) | data source |
+| [mso_tenant.template_tenant](https://registry.terraform.io/providers/CiscoDevNet/mso/latest/docs/data-sources/tenant) | data source |
+| [mso_user.tenant_user](https://registry.terraform.io/providers/CiscoDevNet/mso/latest/docs/data-sources/user) | data source |
 | [utils_yaml_merge.defaults](https://registry.terraform.io/providers/netascode/utils/latest/docs/data-sources/yaml_merge) | data source |
 | [utils_yaml_merge.model](https://registry.terraform.io/providers/netascode/utils/latest/docs/data-sources/yaml_merge) | data source |
 

--- a/ndo_sites.tf
+++ b/ndo_sites.tf
@@ -6,8 +6,3 @@ resource "mso_site" "site" {
     ignore_changes = [urls, username, location]
   }
 }
-
-data "mso_site" "site" {
-  for_each = { for site in try(local.ndo.sites, {}) : site.name => site if !var.manage_sites }
-  name     = each.value.name
-}


### PR DESCRIPTION
Currently the site and tenant data sources are dependent on the sites and tenants keys in the data model. When using multiple workspaces but not referencing the full data model, this can create issues.

For example, if only a file with tenant configuration is passed in, and only manage_tenants is enabled, site level configuration (at least the name) currently needs to be included in the data model:

```
ndo:
  sites:
    - name: APIC1
    - name: APIC2
  tenants:
    - name: TN1
      sites:
        - name: APIC1
        - name: APIC2
```

These changes instead use the sites embedded in the tenant model to generate the data source. Similar changes are made for other data sources.

Optimised tenant example:
```
ndo:
  tenants:
    - name: TN1
      sites:
        - name: APIC1
        - name: APIC2
```

