### PR TITLE
Fix contracts for NDO 4.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,6 @@ $ export TF_CLI_ARGS_apply="-parallelism=1"
 |------|------|
 | [local_sensitive_file.defaults](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/sensitive_file) | resource |
 | [mso_remote_location.remote_location](https://registry.terraform.io/providers/CiscoDevNet/mso/0.11.0/docs/resources/remote_location) | resource |
-| [mso_rest.schema_site_contract](https://registry.terraform.io/providers/CiscoDevNet/mso/0.11.0/docs/resources/rest) | resource |
 | [mso_rest.site_connectivity](https://registry.terraform.io/providers/CiscoDevNet/mso/0.11.0/docs/resources/rest) | resource |
 | [mso_rest.system_config](https://registry.terraform.io/providers/CiscoDevNet/mso/0.11.0/docs/resources/rest) | resource |
 | [mso_schema.schema](https://registry.terraform.io/providers/CiscoDevNet/mso/0.11.0/docs/resources/schema) | resource |
@@ -183,6 +182,7 @@ $ export TF_CLI_ARGS_apply="-parallelism=1"
 | [mso_schema_template_vrf_contract.schema_template_vrf_contract](https://registry.terraform.io/providers/CiscoDevNet/mso/0.11.0/docs/resources/schema_template_vrf_contract) | resource |
 | [mso_site.site](https://registry.terraform.io/providers/CiscoDevNet/mso/0.11.0/docs/resources/site) | resource |
 | [mso_tenant.tenant](https://registry.terraform.io/providers/CiscoDevNet/mso/0.11.0/docs/resources/tenant) | resource |
+| [mso_rest.ndo_version](https://registry.terraform.io/providers/CiscoDevNet/mso/0.11.0/docs/data-sources/rest) | data source |
 | [mso_rest.system_config](https://registry.terraform.io/providers/CiscoDevNet/mso/0.11.0/docs/data-sources/rest) | data source |
 | [mso_schema.schema](https://registry.terraform.io/providers/CiscoDevNet/mso/0.11.0/docs/data-sources/schema) | data source |
 | [mso_schema.template_schema](https://registry.terraform.io/providers/CiscoDevNet/mso/0.11.0/docs/data-sources/schema) | data source |

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ $ export TF_CLI_ARGS_apply="-parallelism=1"
 |------|------|
 | [local_sensitive_file.defaults](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/sensitive_file) | resource |
 | [mso_remote_location.remote_location](https://registry.terraform.io/providers/CiscoDevNet/mso/0.11.0/docs/resources/remote_location) | resource |
+| [mso_rest.schema_site_contract](https://registry.terraform.io/providers/CiscoDevNet/mso/0.11.0/docs/resources/rest) | resource |
 | [mso_rest.site_connectivity](https://registry.terraform.io/providers/CiscoDevNet/mso/0.11.0/docs/resources/rest) | resource |
 | [mso_rest.system_config](https://registry.terraform.io/providers/CiscoDevNet/mso/0.11.0/docs/resources/rest) | resource |
 | [mso_schema.schema](https://registry.terraform.io/providers/CiscoDevNet/mso/0.11.0/docs/resources/schema) | resource |

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,11 @@
 locals {
-  ndo     = try(local.model.ndo, {})
-  schemas = [for schema in try(local.ndo.schemas, []) : schema if var.manage_schemas && (length(var.managed_schemas) == 0 || contains(var.managed_schemas, schema.name))]
-  tenants = [for tenant in try(local.ndo.tenants, []) : tenant if var.manage_tenants && (length(var.managed_tenants) == 0 || contains(var.managed_tenants, tenant.name))]
+  ndo              = try(local.model.ndo, {})
+  schemas          = [for schema in try(local.ndo.schemas, []) : schema if var.manage_schemas && (length(var.managed_schemas) == 0 || contains(var.managed_schemas, schema.name))]
+  tenants          = [for tenant in try(local.ndo.tenants, []) : tenant if var.manage_tenants && (length(var.managed_tenants) == 0 || contains(var.managed_tenants, tenant.name))]
+  ndo_version_full = jsondecode(data.mso_rest.ndo_version.content).version
+  ndo_version      = regex("^[0-9]+[.][0-9]+", local.ndo_version_full)
+}
+
+data "mso_rest" "ndo_version" {
+  path = "api/v1/platform/version"
 }

--- a/ndo_deploy_templates.tf
+++ b/ndo_deploy_templates.tf
@@ -26,7 +26,6 @@ resource "mso_schema_template_deploy_ndo" "template" {
     mso_schema_site.schema_site,
     mso_schema_template_filter_entry.schema_template_filter_entry,
     mso_schema_template_contract.schema_template_contract,
-    mso_rest.schema_site_contract,
     mso_schema_template_contract_filter.schema_template_contract_filter,
     mso_schema_template_contract_service_graph.schema_template_contract_service_graph,
     mso_schema_template_vrf.schema_template_vrf,

--- a/ndo_deploy_templates.tf
+++ b/ndo_deploy_templates.tf
@@ -26,6 +26,7 @@ resource "mso_schema_template_deploy_ndo" "template" {
     mso_schema_site.schema_site,
     mso_schema_template_filter_entry.schema_template_filter_entry,
     mso_schema_template_contract.schema_template_contract,
+    mso_rest.schema_site_contract,
     mso_schema_template_contract_filter.schema_template_contract_filter,
     mso_schema_template_contract_service_graph.schema_template_contract_service_graph,
     mso_schema_template_vrf.schema_template_vrf,

--- a/ndo_schemas.tf
+++ b/ndo_schemas.tf
@@ -163,6 +163,38 @@ locals {
           filter_type   = try(contract.type, local.defaults.ndo.schemas.templates.contracts.type)
           scope         = try(contract.scope, local.defaults.ndo.schemas.templates.contracts.scope)
           directives    = ["none"]
+          filter_relationship = flatten(concat(
+            [
+              for filter in try(contract.filters, []) : {
+                key                  = "${schema.name}/${template.name}/${contract.name}/${filter.name}/both"
+                filter_type          = "bothWay"
+                filter_schema_id     = try(filter.schema, null) != null ? try(mso_schema.schema[filter.schema].id, data.mso_schema.template_schema[filter.schema].id) : null
+                filter_template_name = try(filter.template, null)
+                filter_name          = "${filter.name}${local.defaults.ndo.schemas.templates.filters.name_suffix}"
+                directives           = [try(filter.log, local.defaults.ndo.schemas.templates.contracts.filters.log) ? "log" : "none"]
+              }
+            ],
+            [
+              for filter in try(contract.provider_to_consumer_filters, []) : {
+                key                  = "${schema.name}/${template.name}/${contract.name}/${filter.name}/provider"
+                filter_type          = "provider_to_consumer"
+                filter_schema_id     = try(filter.schema, null) != null ? try(mso_schema.schema[filter.schema].id, data.mso_schema.template_schema[filter.schema].id) : null
+                filter_template_name = try(filter.template, null)
+                filter_name          = "${filter.name}${local.defaults.ndo.schemas.templates.filters.name_suffix}"
+                directives           = [try(filter.log, local.defaults.ndo.schemas.templates.contracts.filters.log) ? "log" : "none"]
+              }
+            ],
+            [
+              for filter in try(contract.consumer_to_provider_filters, []) : {
+                key                  = "${schema.name}/${template.name}/${contract.name}/${filter.name}/consumer"
+                filter_type          = "consumer_to_provider"
+                filter_schema_id     = try(filter.schema, null) != null ? try(mso_schema.schema[filter.schema].id, data.mso_schema.template_schema[filter.schema].id) : null
+                filter_template_name = try(filter.template, null)
+                filter_name          = "${filter.name}${local.defaults.ndo.schemas.templates.filters.name_suffix}"
+                directives           = [try(filter.log, local.defaults.ndo.schemas.templates.contracts.filters.log) ? "log" : "none"]
+              }
+            ]
+          ))
         }
       ]
     ]
@@ -178,44 +210,16 @@ resource "mso_schema_template_contract" "schema_template_contract" {
   filter_type   = each.value.filter_type
   scope         = each.value.scope
   directives    = each.value.directives
-}
+  dynamic "filter_relationship" {
+    for_each = { for filter in try(each.value.filter_relationship, []) : filter.key => filter if local.ndo_version >= 4.0 }
+    content {
+      filter_schema_id     = filter_relationship.value.filter_schema_id
+      filter_template_name = filter_relationship.value.filter_template_name
+      filter_name          = filter_relationship.value.filter_name
+    }
+  }
 
-locals {
-  contracts_sites = flatten([
-    for schema in local.schemas : [
-      for template in try(schema.templates, []) : [
-        for contract in try(template.contracts, []) : [
-          for site in try(template.sites, []) : {
-            key       = "${schema.name}/${template.name}/${contract.name}/${site}"
-            schema_id = mso_schema.schema[schema.name].id
-            patch = [{
-              op   = "add"
-              path = "/sites/${var.manage_sites ? mso_site.site[site].id : data.mso_site.template_site[site].id}-${template.name}/contracts/-"
-              value = {
-                contractRef = {
-                  contractName = "${contract.name}${local.defaults.ndo.schemas.templates.contracts.name_suffix}"
-                  schemaId     = mso_schema.schema[schema.name].id
-                  templateName = template.name
-                }
-              }
-            }]
-          }
-        ]
-      ]
-    ]
-  ])
-}
-
-resource "mso_rest" "schema_site_contract" {
-  for_each = { for contract in local.contracts_sites : contract.key => contract }
-  path     = "api/v1/schemas/${each.value.schema_id}?validate=false"
-  method   = "PATCH"
-  payload  = jsonencode(each.value.patch)
-
-  depends_on = [
-    mso_schema_site.schema_site,
-    mso_schema_template_contract.schema_template_contract,
-  ]
+  depends_on = [mso_schema_template_filter_entry.schema_template_filter_entry]
 }
 
 locals {
@@ -267,7 +271,7 @@ locals {
 }
 
 resource "mso_schema_template_contract_filter" "schema_template_contract_filter" {
-  for_each             = { for filter in local.contracts_filters : filter.key => filter }
+  for_each             = { for filter in local.contracts_filters : filter.key => filter if local.ndo_version < 4.0 }
   schema_id            = each.value.schema_id
   template_name        = each.value.template_name
   contract_name        = each.value.contract_name
@@ -352,7 +356,6 @@ resource "mso_schema_template_contract_service_graph" "schema_template_contract_
   depends_on = [
     mso_schema_template_contract.schema_template_contract,
     mso_schema_template_service_graph.schema_template_service_graph,
-    mso_rest.schema_site_contract,
     mso_schema_template_anp_epg_contract.schema_template_anp_epg_contract,
     mso_schema_template_external_epg_contract.schema_template_external_epg_contract,
     mso_schema_template_vrf_contract.schema_template_vrf_contract,


### PR DESCRIPTION
NDO 4.x rejects the creation of a contract unless the filter(s) are specified. At present, the `mso_schema_template_contract` resource does not have the full functionality of the `mso_schema_template_contract_filter` resource.

In the interim, this change retains `mso_schema_template_contract_filter` for NDO version < 4.0.

For NDO version >= 4.0, we use the `filter_relationship` blocks in the `mso_schema_template_contract` resource to allow contracts to be created, noting that anything other than `bothWay` contract types will not be possible, nor can `directives` be specified on a per-filter basis.

Note: This change also introduces a data source to determine the current NDO version. It is safer than relying on the value provided in the data model.