### PR TITLE
Schema updates

### DIFF
--- a/defaults/defaults.yaml
+++ b/defaults/defaults.yaml
@@ -99,6 +99,8 @@ defaults:
                 primary: false
         vrfs:
           name_suffix: ""
+          data_plane_learning: true
+          preferred_group: false
           l3_multicast: false
           vzany: false
           sites:

--- a/defaults/defaults.yaml
+++ b/defaults/defaults.yaml
@@ -164,3 +164,4 @@ defaults:
           device_name_suffix: ""
           logical_interface_name_suffix: ""
           redirect_policy_name_suffix: ""
+          node_type: "firewall"

--- a/defaults/defaults.yaml
+++ b/defaults/defaults.yaml
@@ -116,6 +116,9 @@ defaults:
           arp_flooding: false
           l2_stretch: true
           l3_multicast: false
+          multi_destination_flooding: bd-flood
+          unknown_ipv4_multicast: flood
+          unknown_ipv6_multicast: flood
           subnets:
             scope: private
             shared: false

--- a/ndo_schemas.tf
+++ b/ndo_schemas.tf
@@ -1616,7 +1616,7 @@ locals {
           schema_id          = mso_schema.schema[schema.name].id
           template_name      = template.name
           service_graph_name = "${sg.name}${local.defaults.ndo.schemas.templates.service_graphs.name_suffix}"
-          service_node_type  = "other"
+          service_node_type  = try(sg.type, local.defaults.ndo.schemas.templates.service_graphs.node_type)
           description        = try(sg.description, null)
           site_nodes = flatten([
             for node in try(sg.nodes, []) : [

--- a/ndo_schemas.tf
+++ b/ndo_schemas.tf
@@ -407,13 +407,15 @@ locals {
     for schema in local.schemas : [
       for template in try(schema.templates, []) : [
         for vrf in try(template.vrfs, []) : {
-          key              = "${schema.name}/${template.name}/${vrf.name}"
-          schema_id        = mso_schema.schema[schema.name].id
-          template_name    = template.name
-          name             = "${vrf.name}${local.defaults.ndo.schemas.templates.vrfs.name_suffix}"
-          display_name     = "${vrf.name}${local.defaults.ndo.schemas.templates.vrfs.name_suffix}"
-          layer3_multicast = try(vrf.l3_multicast, local.defaults.ndo.schemas.templates.vrfs.l3_multicast)
-          vzany            = try(vrf.vzany, local.defaults.ndo.schemas.templates.vrfs.vzany)
+          key                    = "${schema.name}/${template.name}/${vrf.name}"
+          schema_id              = mso_schema.schema[schema.name].id
+          template_name          = template.name
+          name                   = "${vrf.name}${local.defaults.ndo.schemas.templates.vrfs.name_suffix}"
+          display_name           = "${vrf.name}${local.defaults.ndo.schemas.templates.vrfs.name_suffix}"
+          layer3_multicast       = try(vrf.l3_multicast, local.defaults.ndo.schemas.templates.vrfs.l3_multicast)
+          vzany                  = try(vrf.vzany, local.defaults.ndo.schemas.templates.vrfs.vzany)
+          ip_data_plane_learning = try(vrf.data_plane_learning, local.defaults.ndo.schemas.templates.vrfs.data_plane_learning) ? "enabled" : "disabled"
+          preferred_group        = try(vrf.preferred_group, local.defaults.ndo.schemas.templates.vrfs.preferred_group)
         }
       ]
     ]
@@ -421,13 +423,15 @@ locals {
 }
 
 resource "mso_schema_template_vrf" "schema_template_vrf" {
-  for_each         = { for vrf in local.vrfs : vrf.key => vrf }
-  schema_id        = each.value.schema_id
-  template         = each.value.template_name
-  name             = each.value.name
-  display_name     = each.value.display_name
-  layer3_multicast = each.value.layer3_multicast
-  vzany            = each.value.vzany
+  for_each               = { for vrf in local.vrfs : vrf.key => vrf }
+  schema_id              = each.value.schema_id
+  template               = each.value.template_name
+  name                   = each.value.name
+  display_name           = each.value.display_name
+  layer3_multicast       = each.value.layer3_multicast
+  vzany                  = each.value.vzany
+  ip_data_plane_learning = each.value.ip_data_plane_learning
+  preferred_group        = each.value.preferred_group
 }
 
 locals {


### PR DESCRIPTION
Adds support for the following:

1. Manage IP Data-Plane Learning option in VRFs
2. Manage Preferred Group option in VRFs
3. Manage Multi-Destination Flooding option in Bridge Domains
4. Manage IPv4 Unknown Multicast Flooding option in Bridge Domains
5. Manage IPv6 Unknown Multicast Flooding option in Bridge Domains
6. Manage Service Node Type option in Service Graphs (previously hardcoded to "other", now configurable and defaults to "firewall")