### PR TITLE
Add mso_tenant_policies_dhcp_option_policy resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ $ export TF_CLI_ARGS_apply="-parallelism=1"
 | [mso_template.tenant_template](https://registry.terraform.io/providers/CiscoDevNet/mso/latest/docs/resources/template) | resource |
 | [mso_tenant.tenant](https://registry.terraform.io/providers/CiscoDevNet/mso/latest/docs/resources/tenant) | resource |
 | [mso_tenant_policies_bgp_peer_prefix_policy.tenant_policies_bgp_peer_prefix_policy](https://registry.terraform.io/providers/CiscoDevNet/mso/latest/docs/resources/tenant_policies_bgp_peer_prefix_policy) | resource |
+| [mso_tenant_policies_dhcp_option_policy.tenant_policies_dhcp_option_policy](https://registry.terraform.io/providers/CiscoDevNet/mso/latest/docs/resources/tenant_policies_dhcp_option_policy) | resource |
 | [mso_tenant_policies_dhcp_relay_policy.tenant_policies_dhcp_relay_policy](https://registry.terraform.io/providers/CiscoDevNet/mso/latest/docs/resources/tenant_policies_dhcp_relay_policy) | resource |
 | [mso_tenant_policies_ipsla_monitoring_policy.tenant_policies_ipsla_monitoring_policy](https://registry.terraform.io/providers/CiscoDevNet/mso/latest/docs/resources/tenant_policies_ipsla_monitoring_policy) | resource |
 | [mso_tenant_policies_route_map_policy_multicast.tenant_policies_route_map_policy_multicast](https://registry.terraform.io/providers/CiscoDevNet/mso/latest/docs/resources/tenant_policies_route_map_policy_multicast) | resource |

--- a/ndo_tenant_templates.tf
+++ b/ndo_tenant_templates.tf
@@ -244,3 +244,36 @@ resource "mso_tenant_policies_bgp_peer_prefix_policy" "tenant_policies_bgp_peer_
   threshold_percentage   = each.value.threshold
   restart_time           = each.value.restart_time
 }
+
+locals {
+  dhcp_option_policies = flatten([
+    for template in local.tenant_templates : [
+      for policy in try(template.dhcp_option_policies, []) : {
+        name          = policy.name
+        template_name = template.name
+        description   = try(policy.description, null)
+        options = [for option in try(policy.options, []) : {
+          name = option.name
+          id   = try(option.id, null)
+          data = try(option.data, null)
+        }]
+      }
+    ]
+  ])
+}
+
+resource "mso_tenant_policies_dhcp_option_policy" "tenant_policies_dhcp_option_policy" {
+  for_each    = { for policy in local.dhcp_option_policies : policy.name => policy }
+  template_id = mso_template.tenant_template[each.value.template_name].id
+  name        = each.value.name
+  description = each.value.description
+
+  dynamic "options" {
+    for_each = each.value.options
+    content {
+      name = options.value.name
+      id   = options.value.id
+      data = options.value.data
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `mso_tenant_policies_dhcp_option_policy` resource support
- Locals block flattens `dhcp_option_policies` from tenant policy templates
- Supports `options` dynamic block with `name`, `id`, and `data` attributes

Closes #1157

🤖 Generated with [Claude Code](https://claude.com/claude-code)