### PR TITLE
add support for tenant templates l3out interface routing policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ $ export TF_CLI_ARGS_apply="-parallelism=1"
 | [mso_tenant_policies_bgp_peer_prefix_policy.tenant_policies_bgp_peer_prefix_policy](https://registry.terraform.io/providers/CiscoDevNet/mso/latest/docs/resources/tenant_policies_bgp_peer_prefix_policy) | resource |
 | [mso_tenant_policies_dhcp_relay_policy.tenant_policies_dhcp_relay_policy](https://registry.terraform.io/providers/CiscoDevNet/mso/latest/docs/resources/tenant_policies_dhcp_relay_policy) | resource |
 | [mso_tenant_policies_ipsla_monitoring_policy.tenant_policies_ipsla_monitoring_policy](https://registry.terraform.io/providers/CiscoDevNet/mso/latest/docs/resources/tenant_policies_ipsla_monitoring_policy) | resource |
+| [mso_tenant_policies_l3out_interface_routing_policy.tenant_policies_l3out_interface_routing_policy](https://registry.terraform.io/providers/CiscoDevNet/mso/latest/docs/resources/tenant_policies_l3out_interface_routing_policy) | resource |
 | [mso_tenant_policies_route_map_policy_multicast.tenant_policies_route_map_policy_multicast](https://registry.terraform.io/providers/CiscoDevNet/mso/latest/docs/resources/tenant_policies_route_map_policy_multicast) | resource |
 | [terraform_data.validation](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [mso_rest.ndo_version](https://registry.terraform.io/providers/CiscoDevNet/mso/latest/docs/data-sources/rest) | data source |

--- a/README.md
+++ b/README.md
@@ -202,8 +202,8 @@ $ export TF_CLI_ARGS_apply="-parallelism=1"
 | [mso_tenant_policies_dhcp_option_policy.tenant_policies_dhcp_option_policy](https://registry.terraform.io/providers/CiscoDevNet/mso/latest/docs/resources/tenant_policies_dhcp_option_policy) | resource |
 | [mso_tenant_policies_dhcp_relay_policy.tenant_policies_dhcp_relay_policy](https://registry.terraform.io/providers/CiscoDevNet/mso/latest/docs/resources/tenant_policies_dhcp_relay_policy) | resource |
 | [mso_tenant_policies_ipsla_monitoring_policy.tenant_policies_ipsla_monitoring_policy](https://registry.terraform.io/providers/CiscoDevNet/mso/latest/docs/resources/tenant_policies_ipsla_monitoring_policy) | resource |
-| [mso_tenant_policies_l3out_interface_routing_policy.tenant_policies_l3out_interface_routing_policy](https://registry.terraform.io/providers/CiscoDevNet/mso/latest/docs/resources/tenant_policies_l3out_interface_routing_policy) | resource |
 | [mso_tenant_policies_ipsla_track_list.tenant_policies_ipsla_track_list](https://registry.terraform.io/providers/CiscoDevNet/mso/latest/docs/resources/tenant_policies_ipsla_track_list) | resource |
+| [mso_tenant_policies_l3out_interface_routing_policy.tenant_policies_l3out_interface_routing_policy](https://registry.terraform.io/providers/CiscoDevNet/mso/latest/docs/resources/tenant_policies_l3out_interface_routing_policy) | resource |
 | [mso_tenant_policies_route_map_policy_multicast.tenant_policies_route_map_policy_multicast](https://registry.terraform.io/providers/CiscoDevNet/mso/latest/docs/resources/tenant_policies_route_map_policy_multicast) | resource |
 | [terraform_data.validation](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [mso_rest.ndo_version](https://registry.terraform.io/providers/CiscoDevNet/mso/latest/docs/data-sources/rest) | data source |

--- a/defaults/defaults.yaml
+++ b/defaults/defaults.yaml
@@ -202,3 +202,5 @@ defaults:
           max_prefixes: 20000
           threshold: 75
           restart_time: 65534
+        l3out_interface_routing_policies:
+          name_suffix: ""

--- a/defaults/defaults.yaml
+++ b/defaults/defaults.yaml
@@ -227,3 +227,24 @@ defaults:
             priority: unspecified
         l3out_interface_routing_policies:
           name_suffix: ""
+          bfd_multi_hop_settings:
+            admin_state: true
+            detection_multiplier: 3
+            min_rx_interval: 250
+            min_tx_interval: 250
+          bfd_settings:
+            admin_state: true
+            detection_multiplier: 3
+            min_rx_interval: 50
+            min_tx_interval: 50
+            echo_rx_interval: 50
+            echo_admin_state: true
+            interface_control: false
+          ospf_interface_settings:
+            network_type: broadcast
+            priority: 1
+            interface_cost: 0
+            hello_interval: 10
+            dead_interval: 40
+            retransmit_interval: 5
+            transmit_delay: 1

--- a/ndo_deploy_templates.tf
+++ b/ndo_deploy_templates.tf
@@ -108,7 +108,12 @@ resource "mso_schema_template_deploy_ndo" "tenant_template" {
     mso_template.tenant_template,
     mso_tenant_policies_dhcp_relay_policy.tenant_policies_dhcp_relay_policy,
     mso_tenant_policies_ipsla_monitoring_policy.tenant_policies_ipsla_monitoring_policy,
+    mso_tenant_policies_ipsla_track_list.tenant_policies_ipsla_track_list,
     mso_tenant_policies_route_map_policy_multicast.tenant_policies_route_map_policy_multicast,
+    mso_tenant_policies_bgp_peer_prefix_policy.tenant_policies_bgp_peer_prefix_policy,
+    mso_tenant_policies_dhcp_option_policy.tenant_policies_dhcp_option_policy,
+    mso_tenant_policies_custom_qos_policy.tenant_policies_custom_qos_policy,
+    mso_tenant_policies_l3out_interface_routing_policy.tenant_policies_l3out_interface_routing_policy,
   ]
 }
 

--- a/ndo_tenant_templates.tf
+++ b/ndo_tenant_templates.tf
@@ -396,32 +396,32 @@ locals {
         template_name = template.name
         description   = try(policy.description, null)
         bfd_multi_hop_settings = try(policy.bfd_multi_hop_settings, null) != null ? {
-          admin_state           = try(policy.bfd_multi_hop_settings.admin_state, null) != null ? (policy.bfd_multi_hop_settings.admin_state ? "enabled" : "disabled") : null
-          detection_multiplier  = try(policy.bfd_multi_hop_settings.detection_multiplier, null)
-          min_receive_interval  = try(policy.bfd_multi_hop_settings.min_rx_interval, null)
-          min_transmit_interval = try(policy.bfd_multi_hop_settings.min_tx_interval, null)
+          admin_state           = try(policy.bfd_multi_hop_settings.admin_state, local.defaults.ndo.tenant_templates.tenant_policies.l3out_interface_routing_policies.bfd_multi_hop_settings.admin_state) != null ? (policy.bfd_multi_hop_settings.admin_state ? "enabled" : "disabled") : null
+          detection_multiplier  = try(policy.bfd_multi_hop_settings.detection_multiplier, local.defaults.ndo.tenant_templates.tenant_policies.l3out_interface_routing_policies.bfd_multi_hop_settings.detection_multiplier)
+          min_receive_interval  = try(policy.bfd_multi_hop_settings.min_rx_interval, local.defaults.ndo.tenant_templates.tenant_policies.l3out_interface_routing_policies.bfd_multi_hop_settings.min_rx_interval)
+          min_transmit_interval = try(policy.bfd_multi_hop_settings.min_tx_interval, local.defaults.ndo.tenant_templates.tenant_policies.l3out_interface_routing_policies.bfd_multi_hop_settings.min_tx_interval)
         } : null
         bfd_settings = try(policy.bfd_settings, null) != null ? {
-          admin_state           = try(policy.bfd_settings.admin_state, null) != null ? (policy.bfd_settings.admin_state ? "enabled" : "disabled") : null
-          detection_multiplier  = try(policy.bfd_settings.detection_multiplier, null)
-          min_receive_interval  = try(policy.bfd_settings.min_rx_interval, null)
-          min_transmit_interval = try(policy.bfd_settings.min_tx_interval, null)
-          echo_receive_interval = try(policy.bfd_settings.echo_rx_interval, null)
-          echo_admin_state      = try(policy.bfd_settings.echo_admin_state, null) != null ? (policy.bfd_settings.echo_admin_state ? "enabled" : "disabled") : null
-          interface_control     = try(policy.bfd_settings.interface_control, null)
+          admin_state           = try(policy.bfd_settings.admin_state, local.defaults.ndo.tenant_templates.tenant_policies.l3out_interface_routing_policies.bfd_settings.admin_state) ? "enabled" : "disabled"
+          detection_multiplier  = try(policy.bfd_settings.detection_multiplier, local.defaults.ndo.tenant_templates.tenant_policies.l3out_interface_routing_policies.bfd_settings.detection_multiplier)
+          min_receive_interval  = try(policy.bfd_settings.min_rx_interval, local.defaults.ndo.tenant_templates.tenant_policies.l3out_interface_routing_policies.bfd_settings.min_rx_interval)
+          min_transmit_interval = try(policy.bfd_settings.min_tx_interval, local.defaults.ndo.tenant_templates.tenant_policies.l3out_interface_routing_policies.bfd_settings.min_tx_interval)
+          echo_receive_interval = try(policy.bfd_settings.echo_rx_interval, local.defaults.ndo.tenant_templates.tenant_policies.l3out_interface_routing_policies.bfd_settings.echo_rx_interval)
+          echo_admin_state      = try(policy.bfd_settings.echo_admin_state, local.defaults.ndo.tenant_templates.tenant_policies.l3out_interface_routing_policies.bfd_settings.echo_admin_state) ? "enabled" : "disabled"
+          interface_control     = try(policy.bfd_settings.interface_control, local.defaults.ndo.tenant_templates.tenant_policies.l3out_interface_routing_policies.bfd_settings.interface_control)
         } : null
         ospf_interface_settings = try(policy.ospf_interface_settings, null) != null ? {
-          network_type          = try(policy.ospf_interface_settings.network_type, null) == "point-to-point" ? "point_to_point" : try(policy.ospf_interface_settings.network_type, null) == "broadcast" ? "broadcast" : null
-          priority              = try(policy.ospf_interface_settings.priority, null)
-          cost                  = try(policy.ospf_interface_settings.cost, null)
-          hello_interval        = try(policy.ospf_interface_settings.hello_interval, null)
-          dead_interval         = try(policy.ospf_interface_settings.dead_interval, null)
-          retransmit_interval   = try(policy.ospf_interface_settings.retransmit_interval, null)
-          transmit_delay        = try(policy.ospf_interface_settings.transmit_delay, null)
-          advertise_subnet      = try(policy.ospf_interface_settings.advertise_subnet, null)
-          bfd                   = try(policy.ospf_interface_settings.bfd, null)
-          mtu_ignore            = try(policy.ospf_interface_settings.mtu_ignore, null)
-          passive_participation = try(policy.ospf_interface_settings.passive_participation, null)
+          network_type          = try(policy.ospf_interface_settings.network_type, local.defaults.ndo.tenant_templates.tenant_policies.l3out_interface_routing_policies.ospf_interface_settings.network_type) == "point-to-point" ? "point_to_point" : try(policy.ospf_interface_settings.network_type, local.defaults.ndo.tenant_templates.tenant_policies.l3out_interface_routing_policies.ospf_interface_settings.network_type) == "broadcast" ? "broadcast" : null
+          priority              = try(policy.ospf_interface_settings.priority, local.defaults.ndo.tenant_templates.tenant_policies.l3out_interface_routing_policies.ospf_interface_settings.priority)
+          interface_cost        = try(policy.ospf_interface_settings.interface_cost, local.defaults.ndo.tenant_templates.tenant_policies.l3out_interface_routing_policies.ospf_interface_settings.interface_cost)
+          hello_interval        = try(policy.ospf_interface_settings.hello_interval, local.defaults.ndo.tenant_templates.tenant_policies.l3out_interface_routing_policies.ospf_interface_settings.hello_interval)
+          dead_interval         = try(policy.ospf_interface_settings.dead_interval, local.defaults.ndo.tenant_templates.tenant_policies.l3out_interface_routing_policies.ospf_interface_settings.dead_interval)
+          retransmit_interval   = try(policy.ospf_interface_settings.retransmit_interval, local.defaults.ndo.tenant_templates.tenant_policies.l3out_interface_routing_policies.ospf_interface_settings.retransmit_interval)
+          transmit_delay        = try(policy.ospf_interface_settings.transmit_delay, local.defaults.ndo.tenant_templates.tenant_policies.l3out_interface_routing_policies.ospf_interface_settings.transmit_delay)
+          advertise_subnet      = try(policy.ospf_interface_settings.advertise_subnet, local.defaults.ndo.tenant_templates.tenant_policies.l3out_interface_routing_policies.ospf_interface_settings.advertise_subnet)
+          bfd                   = try(policy.ospf_interface_settings.bfd, local.defaults.ndo.tenant_templates.tenant_policies.l3out_interface_routing_policies.ospf_interface_settings.bfd)
+          mtu_ignore            = try(policy.ospf_interface_settings.mtu_ignore, local.defaults.ndo.tenant_templates.tenant_policies.l3out_interface_routing_policies.ospf_interface_settings.mtu_ignore)
+          passive_participation = try(policy.ospf_interface_settings.passive_participation, local.defaults.ndo.tenant_templates.tenant_policies.l3out_interface_routing_policies.ospf_interface_settings.passive_participation)
         } : null
       }
     ]
@@ -462,7 +462,7 @@ resource "mso_tenant_policies_l3out_interface_routing_policy" "tenant_policies_l
     content {
       network_type          = ospf_interface_settings.value.network_type
       priority              = ospf_interface_settings.value.priority
-      cost_of_interface     = ospf_interface_settings.value.cost
+      cost_of_interface     = ospf_interface_settings.value.interface_cost
       hello_interval        = ospf_interface_settings.value.hello_interval
       dead_interval         = ospf_interface_settings.value.dead_interval
       retransmit_interval   = ospf_interface_settings.value.retransmit_interval

--- a/ndo_tenant_templates.tf
+++ b/ndo_tenant_templates.tf
@@ -244,3 +244,90 @@ resource "mso_tenant_policies_bgp_peer_prefix_policy" "tenant_policies_bgp_peer_
   threshold_percentage   = each.value.threshold
   restart_time           = each.value.restart_time
 }
+
+locals {
+  l3out_interface_routing_policies = flatten([
+    for template in local.tenant_templates : [
+      for policy in try(template.l3out_interface_routing_policies, []) : {
+        name          = policy.name
+        template_name = template.name
+        description   = try(policy.description, null)
+        bfd_multi_hop_settings = try(policy.bfd_multi_hop_settings, null) != null ? {
+          admin_state           = try(policy.bfd_multi_hop_settings.admin_state, null)
+          detection_multiplier  = try(policy.bfd_multi_hop_settings.detection_multiplier, null)
+          min_receive_interval  = try(policy.bfd_multi_hop_settings.min_receive_interval, null)
+          min_transmit_interval = try(policy.bfd_multi_hop_settings.min_transmit_interval, null)
+        } : null
+        bfd_settings = try(policy.bfd_settings, null) != null ? {
+          admin_state           = try(policy.bfd_settings.admin_state, null)
+          detection_multiplier  = try(policy.bfd_settings.detection_multiplier, null)
+          min_receive_interval  = try(policy.bfd_settings.min_receive_interval, null)
+          min_transmit_interval = try(policy.bfd_settings.min_transmit_interval, null)
+          echo_receive_interval = try(policy.bfd_settings.echo_receive_interval, null)
+          echo_admin_state      = try(policy.bfd_settings.echo_admin_state, null)
+          interface_control     = try(policy.bfd_settings.interface_control, null)
+        } : null
+        ospf_interface_settings = try(policy.ospf_interface_settings, null) != null ? {
+          network_type          = try(policy.ospf_interface_settings.network_type, null)
+          priority              = try(policy.ospf_interface_settings.priority, null)
+          cost_of_interface     = try(policy.ospf_interface_settings.cost_of_interface, null)
+          hello_interval        = try(policy.ospf_interface_settings.hello_interval, null)
+          dead_interval         = try(policy.ospf_interface_settings.dead_interval, null)
+          retransmit_interval   = try(policy.ospf_interface_settings.retransmit_interval, null)
+          transmit_delay        = try(policy.ospf_interface_settings.transmit_delay, null)
+          advertise_subnet      = try(policy.ospf_interface_settings.advertise_subnet, null)
+          bfd                   = try(policy.ospf_interface_settings.bfd, null)
+          mtu_ignore            = try(policy.ospf_interface_settings.mtu_ignore, null)
+          passive_participation = try(policy.ospf_interface_settings.passive_participation, null)
+        } : null
+      }
+    ]
+  ])
+}
+
+resource "mso_tenant_policies_l3out_interface_routing_policy" "tenant_policies_l3out_interface_routing_policy" {
+  for_each    = { for policy in local.l3out_interface_routing_policies : policy.name => policy }
+  template_id = mso_template.tenant_template[each.value.template_name].id
+  name        = each.value.name
+  description = each.value.description
+
+  dynamic "bfd_multi_hop_settings" {
+    for_each = each.value.bfd_multi_hop_settings != null ? [each.value.bfd_multi_hop_settings] : []
+    content {
+      admin_state           = bfd_multi_hop_settings.value.admin_state
+      detection_multiplier  = bfd_multi_hop_settings.value.detection_multiplier
+      min_receive_interval  = bfd_multi_hop_settings.value.min_receive_interval
+      min_transmit_interval = bfd_multi_hop_settings.value.min_transmit_interval
+    }
+  }
+
+  dynamic "bfd_settings" {
+    for_each = each.value.bfd_settings != null ? [each.value.bfd_settings] : []
+    content {
+      admin_state           = bfd_settings.value.admin_state
+      detection_multiplier  = bfd_settings.value.detection_multiplier
+      min_receive_interval  = bfd_settings.value.min_receive_interval
+      min_transmit_interval = bfd_settings.value.min_transmit_interval
+      echo_receive_interval = bfd_settings.value.echo_receive_interval
+      echo_admin_state      = bfd_settings.value.echo_admin_state
+      interface_control     = bfd_settings.value.interface_control
+    }
+  }
+
+  dynamic "ospf_interface_settings" {
+    for_each = each.value.ospf_interface_settings != null ? [each.value.ospf_interface_settings] : []
+    content {
+      network_type          = ospf_interface_settings.value.network_type
+      priority              = ospf_interface_settings.value.priority
+      cost_of_interface     = ospf_interface_settings.value.cost_of_interface
+      hello_interval        = ospf_interface_settings.value.hello_interval
+      dead_interval         = ospf_interface_settings.value.dead_interval
+      retransmit_interval   = ospf_interface_settings.value.retransmit_interval
+      transmit_delay        = ospf_interface_settings.value.transmit_delay
+      advertise_subnet      = ospf_interface_settings.value.advertise_subnet
+      bfd                   = ospf_interface_settings.value.bfd
+      mtu_ignore            = ospf_interface_settings.value.mtu_ignore
+      passive_participation = ospf_interface_settings.value.passive_participation
+    }
+  }
+}

--- a/ndo_tenant_templates.tf
+++ b/ndo_tenant_templates.tf
@@ -185,13 +185,15 @@ resource "mso_tenant_policies_ipsla_monitoring_policy" "tenant_policies_ipsla_mo
 locals {
   ipsla_track_lists = flatten([
     for template in local.tenant_templates : [
-      for policy in try(template.ipsla_track_lists, []) : {
-        name           = policy.name
-        template_name  = template.name
-        description    = try(policy.description, null)
-        type           = try(policy.type, local.defaults.ndo.tenant_templates.tenant_policies.ipsla_track_lists.type)
-        threshold_up   = try(policy.threshold_up, local.defaults.ndo.tenant_templates.tenant_policies.ipsla_track_lists.threshold_up)
-        threshold_down = try(policy.threshold_down, local.defaults.ndo.tenant_templates.tenant_policies.ipsla_track_lists.threshold_down)
+      for policy in try(template.ip_sla_track_lists, []) : {
+        name            = policy.name
+        template_name   = template.name
+        description     = try(policy.description, null)
+        type            = try(policy.type, local.defaults.ndo.tenant_templates.tenant_policies.ip_sla_track_lists.type)
+        percentage_up   = try(policy.percentage_up, local.defaults.ndo.tenant_templates.tenant_policies.ip_sla_track_lists.percentage_up)
+        percentage_down = try(policy.percentage_down, local.defaults.ndo.tenant_templates.tenant_policies.ip_sla_track_lists.percentage_down)
+        weight_up       = try(policy.weight_up, local.defaults.ndo.tenant_templates.tenant_policies.ip_sla_track_lists.weight_up)
+        weight_down     = try(policy.weight_down, local.defaults.ndo.tenant_templates.tenant_policies.ip_sla_track_lists.weight_down)
         members = [for member in try(policy.members, []) : {
           destination_ip               = member.destination_ip
           ipsla_monitoring_policy_name = member.ip_sla_policy
@@ -209,8 +211,8 @@ resource "mso_tenant_policies_ipsla_track_list" "tenant_policies_ipsla_track_lis
   name           = each.value.name
   description    = each.value.description
   type           = each.value.type
-  threshold_up   = each.value.threshold_up
-  threshold_down = each.value.threshold_down
+  threshold_up   = each.value.type == "percentage" ? each.value.percentage_up : each.value.weight_up
+  threshold_down = each.value.type == "percentage" ? each.value.percentage_down : each.value.weight_down
 
   dynamic "members" {
     for_each = each.value.members
@@ -390,7 +392,7 @@ locals {
   l3out_interface_routing_policies = flatten([
     for template in local.tenant_templates : [
       for policy in try(template.l3out_interface_routing_policies, []) : {
-        name          = policy.name
+        name          = "${policy.name}${local.defaults.ndo.tenant_templates.tenant_policies.l3out_interface_routing_policies.name_suffix}"
         template_name = template.name
         description   = try(policy.description, null)
         bfd_multi_hop_settings = try(policy.bfd_multi_hop_settings, null) != null ? {
@@ -409,7 +411,7 @@ locals {
           interface_control     = try(policy.bfd_settings.interface_control, null)
         } : null
         ospf_interface_settings = try(policy.ospf_interface_settings, null) != null ? {
-          network_type          = try(policy.ospf_interface_settings.network_type, null)
+          network_type          = try(policy.ospf_interface_settings.network_type, null) == "point-to-point" ? "point_to_point" : try(policy.ospf_interface_settings.network_type, null) == "broadcast" ? "broadcast" : null
           priority              = try(policy.ospf_interface_settings.priority, null)
           cost                  = try(policy.ospf_interface_settings.cost, null)
           hello_interval        = try(policy.ospf_interface_settings.hello_interval, null)

--- a/ndo_tenant_templates.tf
+++ b/ndo_tenant_templates.tf
@@ -394,24 +394,24 @@ locals {
         template_name = template.name
         description   = try(policy.description, null)
         bfd_multi_hop_settings = try(policy.bfd_multi_hop_settings, null) != null ? {
-          admin_state           = try(policy.bfd_multi_hop_settings.admin_state, null)
+          admin_state           = try(policy.bfd_multi_hop_settings.admin_state, null) != null ? (policy.bfd_multi_hop_settings.admin_state ? "enabled" : "disabled") : null
           detection_multiplier  = try(policy.bfd_multi_hop_settings.detection_multiplier, null)
-          min_receive_interval  = try(policy.bfd_multi_hop_settings.min_receive_interval, null)
-          min_transmit_interval = try(policy.bfd_multi_hop_settings.min_transmit_interval, null)
+          min_receive_interval  = try(policy.bfd_multi_hop_settings.min_rx_interval, null)
+          min_transmit_interval = try(policy.bfd_multi_hop_settings.min_tx_interval, null)
         } : null
         bfd_settings = try(policy.bfd_settings, null) != null ? {
-          admin_state           = try(policy.bfd_settings.admin_state, null)
+          admin_state           = try(policy.bfd_settings.admin_state, null) != null ? (policy.bfd_settings.admin_state ? "enabled" : "disabled") : null
           detection_multiplier  = try(policy.bfd_settings.detection_multiplier, null)
-          min_receive_interval  = try(policy.bfd_settings.min_receive_interval, null)
-          min_transmit_interval = try(policy.bfd_settings.min_transmit_interval, null)
-          echo_receive_interval = try(policy.bfd_settings.echo_receive_interval, null)
-          echo_admin_state      = try(policy.bfd_settings.echo_admin_state, null)
+          min_receive_interval  = try(policy.bfd_settings.min_rx_interval, null)
+          min_transmit_interval = try(policy.bfd_settings.min_tx_interval, null)
+          echo_receive_interval = try(policy.bfd_settings.echo_rx_interval, null)
+          echo_admin_state      = try(policy.bfd_settings.echo_admin_state, null) != null ? (policy.bfd_settings.echo_admin_state ? "enabled" : "disabled") : null
           interface_control     = try(policy.bfd_settings.interface_control, null)
         } : null
         ospf_interface_settings = try(policy.ospf_interface_settings, null) != null ? {
           network_type          = try(policy.ospf_interface_settings.network_type, null)
           priority              = try(policy.ospf_interface_settings.priority, null)
-          cost_of_interface     = try(policy.ospf_interface_settings.cost_of_interface, null)
+          cost                  = try(policy.ospf_interface_settings.cost, null)
           hello_interval        = try(policy.ospf_interface_settings.hello_interval, null)
           dead_interval         = try(policy.ospf_interface_settings.dead_interval, null)
           retransmit_interval   = try(policy.ospf_interface_settings.retransmit_interval, null)
@@ -460,7 +460,7 @@ resource "mso_tenant_policies_l3out_interface_routing_policy" "tenant_policies_l
     content {
       network_type          = ospf_interface_settings.value.network_type
       priority              = ospf_interface_settings.value.priority
-      cost_of_interface     = ospf_interface_settings.value.cost_of_interface
+      cost_of_interface     = ospf_interface_settings.value.cost
       hello_interval        = ospf_interface_settings.value.hello_interval
       dead_interval         = ospf_interface_settings.value.dead_interval
       retransmit_interval   = ospf_interface_settings.value.retransmit_interval


### PR DESCRIPTION
## Summary
- Add locals and resource for `mso_tenant_policies_l3out_interface_routing_policy`
- Supports BFD multi-hop settings, BFD settings, and OSPF interface settings via dynamic blocks
- Add defaults for l3out_interface_routing_policies

## Test plan
- [ ] Verify `terraform validate` passes
- [ ] Deploy tenant template with L3Out interface routing policy with all sub-settings
- [ ] Verify policy appears correctly in NDO UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)