### PR TITLE
Add support for MLD snooping policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ $ export TF_CLI_ARGS_apply="-parallelism=1"
 | [mso_tenant_policies_ipsla_monitoring_policy.tenant_policies_ipsla_monitoring_policy](https://registry.terraform.io/providers/CiscoDevNet/mso/latest/docs/resources/tenant_policies_ipsla_monitoring_policy) | resource |
 | [mso_tenant_policies_ipsla_track_list.tenant_policies_ipsla_track_list](https://registry.terraform.io/providers/CiscoDevNet/mso/latest/docs/resources/tenant_policies_ipsla_track_list) | resource |
 | [mso_tenant_policies_l3out_interface_routing_policy.tenant_policies_l3out_interface_routing_policy](https://registry.terraform.io/providers/CiscoDevNet/mso/latest/docs/resources/tenant_policies_l3out_interface_routing_policy) | resource |
+| [mso_tenant_policies_mld_snooping_policy.tenant_policies_mld_snooping_policy](https://registry.terraform.io/providers/CiscoDevNet/mso/latest/docs/resources/tenant_policies_mld_snooping_policy) | resource |
 | [mso_tenant_policies_route_map_policy_multicast.tenant_policies_route_map_policy_multicast](https://registry.terraform.io/providers/CiscoDevNet/mso/latest/docs/resources/tenant_policies_route_map_policy_multicast) | resource |
 | [terraform_data.validation](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [mso_rest.ndo_version](https://registry.terraform.io/providers/CiscoDevNet/mso/latest/docs/data-sources/rest) | data source |

--- a/ndo_tenant_templates.tf
+++ b/ndo_tenant_templates.tf
@@ -474,3 +474,40 @@ resource "mso_tenant_policies_l3out_interface_routing_policy" "tenant_policies_l
     }
   }
 }
+
+locals {
+  mld_snooping_policies = flatten([
+    for template in local.tenant_templates : [
+      for policy in try(template.mld_snooping_policies, []) : {
+        name                       = "${policy.name}${local.defaults.ndo.tenant_templates.tenant_policies.mld_snooping_policies.name_suffix}"
+        template_name              = template.name
+        description                = try(policy.description, null)
+        admin_state                = try(policy.admin_state, local.defaults.ndo.tenant_templates.tenant_policies.mld_snooping_policies.admin_state) ? "enabled" : "disabled"
+        fast_leave_control         = try(policy.fast_leave_control, local.defaults.ndo.tenant_templates.tenant_policies.mld_snooping_policies.fast_leave_control)
+        querier_control            = try(policy.querier_control, local.defaults.ndo.tenant_templates.tenant_policies.mld_snooping_policies.querier_control)
+        querier_version            = try(policy.querier_version, local.defaults.ndo.tenant_templates.tenant_policies.mld_snooping_policies.querier_version)
+        query_interval             = try(policy.query_interval, local.defaults.ndo.tenant_templates.tenant_policies.mld_snooping_policies.query_interval)
+        query_response_interval    = try(policy.query_response_interval, local.defaults.ndo.tenant_templates.tenant_policies.mld_snooping_policies.query_response_interval)
+        last_member_query_interval = try(policy.last_member_query_interval, local.defaults.ndo.tenant_templates.tenant_policies.mld_snooping_policies.last_member_query_interval)
+        start_query_interval       = try(policy.start_query_interval, local.defaults.ndo.tenant_templates.tenant_policies.mld_snooping_policies.start_query_interval)
+        start_query_count          = try(policy.start_query_count, local.defaults.ndo.tenant_templates.tenant_policies.mld_snooping_policies.start_query_count)
+      }
+    ]
+  ])
+}
+
+resource "mso_tenant_policies_mld_snooping_policy" "tenant_policies_mld_snooping_policy" {
+  for_each                   = { for policy in local.mld_snooping_policies : policy.name => policy }
+  template_id                = mso_template.tenant_template[each.value.template_name].id
+  name                       = each.value.name
+  description                = each.value.description
+  admin_state                = each.value.admin_state
+  fast_leave_control         = each.value.fast_leave_control
+  querier_control            = each.value.querier_control
+  querier_version            = each.value.querier_version
+  query_interval             = each.value.query_interval
+  query_response_interval    = each.value.query_response_interval
+  last_member_query_interval = each.value.last_member_query_interval
+  start_query_interval       = each.value.start_query_interval
+  start_query_count          = each.value.start_query_count
+}


### PR DESCRIPTION
## Summary
- Add `mso_tenant_policies_mld_snooping_policy` resource to tenant templates
- Supports all attributes: admin_state, fast_leave_control, querier_control, querier_version, query_interval, query_response_interval, last_member_query_interval, start_query_interval, start_query_count
- Requires NDO v4.3+

## Test plan
- [ ] Run integration tests against NDO 4.4+
- [ ] Verify MLD snooping policy creation with full and minimal config